### PR TITLE
Revert "Minimal version workaround for crc32fast"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ version-sync = "0.9.1"
 
 [dependencies]
 chrono = "0.4.19"
-crc32fast = { version = "1.1.1", default-features = false } # -Z minimal-versions workaround
 enumflags2 = "0.6.4"
 hex = "0.4.2"
 shell-escape = "0.1.5"


### PR DESCRIPTION
Waiting on https://github.com/srijs/rust-crc32fast/issues/18.